### PR TITLE
Fix bug to allow dash

### DIFF
--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -17,7 +17,7 @@ public class Name {
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} .'-()]"
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} .'-()-]"
             + "*( s/o [\\p{Alnum} ]+| d/o [\\p{Alnum} ]+)?";
 
     public final String fullName;


### PR DESCRIPTION
Fixes #359

We have intended to allow dashes in the name and this was explicitly stated in the error message as shown, but a minor bug in the regex resulted in the input being rejected. Refer to PR #283 and PR #213. We intended to allow dashes, but a small missing dash resulted in the bug.