### PR TITLE
Fix spelling in error message

### DIFF
--- a/src/main/java/seedu/address/model/person/Fees.java
+++ b/src/main/java/seedu/address/model/person/Fees.java
@@ -10,7 +10,7 @@ public class Fees {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Fees should be a positive integer, only contain numbers, and should be at least 1 digit long"
-                    + "and a maximum of 9 digits long.";
+                    + " and a maximum of 9 digits long.";
 
     /*
      * The first character of the address must not be a whitespace,


### PR DESCRIPTION
Spelling fixes are allowed 

Fixes #302

<img width="758" alt="Screenshot 2024-11-11 at 2 17 42 PM" src="https://github.com/user-attachments/assets/7a304124-35bc-48ba-bf8c-6485227ffe13">
